### PR TITLE
Add static-dispatch versions

### DIFF
--- a/num-utils.asd
+++ b/num-utils.asd
@@ -43,15 +43,46 @@
    (:file "test-utilities")
    (:file "pkgdcl")))
 
+(defsystem "num-utils/static-dispatch"
+  :description "Numerical utilities for Common Lisp enhanced by STATIC-DISPATCH."
+  :depends-on (#:anaphora
+               #:alexandria
+               #:alexandria+
+               #:array-operations
+               #:select
+               #:let-plus
+               #:static-dispatch)
+  :pathname "static-dispatch/"
+  :serial t
+  :components
+  ((:file "packages")
+   (:file "utilities")
+   (:file "num=")
+   (:file "arithmetic")
+;;   (:file "arithmetic-type") ; now in src/old/ Looks like it was a WIP
+   (:file "elementwise")
+   (:file "extended-real")
+   (:file "interval")
+   (:file "print-matrix")
+   (:file "matrix")
+   (:file "matrix-shorthand")
+   (:file "chebyshev")
+   (:file "polynomial")
+   (:file "rootfinding")
+   (:file "quadrature")
+   (:file "log-exp")
+   (:file "test-utilities")
+   (:file "pkgdcl")))
+
 (defsystem "num-utils/tests"
   :version "1.0.0"
   :description "Unit tests for NUM-UTILS."
   :author "Steven Nunez <steve@symbolics.tech>"
   :license "Same as NUM-UTILS -- this is part of the NUM-UTILS library."
   #+asdf-unicode :encoding #+asdf-unicode :utf-8
-  :depends-on (#:num-utils
+  :depends-on (#:num-utils/static-dispatch
                #:fiveam
-	       #:select) ; matrix test needs this
+               #:select) ; matrix test needs this
   :pathname "tests/"
   :serial t
   :components
@@ -75,4 +106,36 @@
   :perform (test-op (o s)
 			 (uiop:symbol-call :fiveam :run!
 					   (uiop:find-symbol* :all-tests
-							      :num-utils-tests))))
+                                  :num-utils-tests))))
+
+(defsystem "num-utils/static-dispatch/tests"
+  :description "Unit tests for NUM-UTILS/STATIC-DISPATCH."
+  :license "Same as NUM-UTILS -- this is part of the NUM-UTILS library."
+  #+asdf-unicode :encoding #+asdf-unicode :utf-8
+  :depends-on (#:num-utils/static-dispatch
+               #:fiveam
+               #:select) ; matrix test needs this
+  :pathname "static-dispatch-tests/"
+  :serial t
+  :components
+  ((:file "test-package")
+   (:file "main")
+   ;; in alphabetical order
+   (:file "arithmetic")
+;; (:file "arithmetic-type") ; No tests included in Papp's version
+   (:file "chebyshev")
+   (:file "polynomial")
+   (:file "elementwise")
+   (:file "extended-real")
+   (:file "interval")
+   (:file "matrix")
+   (:file "matrix-shorthand")
+   (:file "num=")
+   (:file "quadrature")
+   (:file "rootfinding")
+   (:file "log-exp")
+   (:file "utilities"))
+  :perform (test-op (o s)
+             (uiop:symbol-call :fiveam :run!
+                       (uiop:find-symbol* :all-tests
+                                  :num-utils-tests))))

--- a/num-utils.asd
+++ b/num-utils.asd
@@ -52,6 +52,7 @@
                #:select
                #:let-plus
                #:static-dispatch)
+  :in-order-to ((test-op (test-op "num-utils/static-dispatch/tests")))
   :pathname "static-dispatch/"
   :serial t
   :components
@@ -80,7 +81,7 @@
   :author "Steven Nunez <steve@symbolics.tech>"
   :license "Same as NUM-UTILS -- this is part of the NUM-UTILS library."
   #+asdf-unicode :encoding #+asdf-unicode :utf-8
-  :depends-on (#:num-utils/static-dispatch
+  :depends-on (#:num-utils
                #:fiveam
                #:select) ; matrix test needs this
   :pathname "tests/"

--- a/static-dispatch-tests/arithmetic.lisp
+++ b/static-dispatch-tests/arithmetic.lisp
@@ -1,0 +1,1 @@
+../tests/arithmetic.lisp

--- a/static-dispatch-tests/chebyshev.lisp
+++ b/static-dispatch-tests/chebyshev.lisp
@@ -1,0 +1,1 @@
+../tests/chebyshev.lisp

--- a/static-dispatch-tests/elementwise.lisp
+++ b/static-dispatch-tests/elementwise.lisp
@@ -1,0 +1,1 @@
+../tests/elementwise.lisp

--- a/static-dispatch-tests/extended-real.lisp
+++ b/static-dispatch-tests/extended-real.lisp
@@ -1,0 +1,1 @@
+../tests/extended-real.lisp

--- a/static-dispatch-tests/interval.lisp
+++ b/static-dispatch-tests/interval.lisp
@@ -1,0 +1,1 @@
+../tests/interval.lisp

--- a/static-dispatch-tests/log-exp.lisp
+++ b/static-dispatch-tests/log-exp.lisp
@@ -1,0 +1,1 @@
+../tests/log-exp.lisp

--- a/static-dispatch-tests/main.lisp
+++ b/static-dispatch-tests/main.lisp
@@ -1,0 +1,1 @@
+../tests/main.lisp

--- a/static-dispatch-tests/matrix-shorthand.lisp
+++ b/static-dispatch-tests/matrix-shorthand.lisp
@@ -1,0 +1,1 @@
+../tests/matrix-shorthand.lisp

--- a/static-dispatch-tests/matrix.lisp
+++ b/static-dispatch-tests/matrix.lisp
@@ -1,0 +1,1 @@
+../tests/matrix.lisp

--- a/static-dispatch-tests/num=.lisp
+++ b/static-dispatch-tests/num=.lisp
@@ -1,0 +1,1 @@
+../tests/num=.lisp

--- a/static-dispatch-tests/polynomial.lisp
+++ b/static-dispatch-tests/polynomial.lisp
@@ -1,0 +1,1 @@
+../tests/polynomial.lisp

--- a/static-dispatch-tests/quadrature.lisp
+++ b/static-dispatch-tests/quadrature.lisp
@@ -1,0 +1,1 @@
+../tests/quadrature.lisp

--- a/static-dispatch-tests/rootfinding.lisp
+++ b/static-dispatch-tests/rootfinding.lisp
@@ -1,0 +1,1 @@
+../tests/rootfinding.lisp

--- a/static-dispatch-tests/test-package.lisp
+++ b/static-dispatch-tests/test-package.lisp
@@ -1,0 +1,26 @@
+;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-Lisp; Package: CL-USER -*-
+;;; Copyright (c) 2021-2022 by Symbolics Pte. Ltd. All rights reserved.
+
+(uiop:define-package #:num-utils-tests
+  (:use #:static-dispatch-cl
+        #:alexandria
+        #:anaphora
+        #:let-plus
+        #:fiveam
+        #:select
+
+        ;; num-utils subpackages (alphabetical order)
+        #:num-utils.arithmetic
+        #:num-utils.chebyshev
+        #:num-utils.elementwise
+        #:num-utils.interval
+	#:num-utils.log-exp
+        #:num-utils.matrix
+        #:num-utils.matrix-shorthand
+        #:num-utils.num=
+        #:num-utils.polynomial
+        #:num-utils.quadrature
+        #:num-utils.rootfinding
+	#:num-utils.test-utilities
+        #:num-utils.utilities)
+  (:export #:run))

--- a/static-dispatch-tests/utilities.lisp
+++ b/static-dispatch-tests/utilities.lisp
@@ -1,0 +1,1 @@
+../tests/utilities.lisp

--- a/static-dispatch/arithmetic.lisp
+++ b/static-dispatch/arithmetic.lisp
@@ -1,0 +1,1 @@
+../src/../src/arithmetic.lisp

--- a/static-dispatch/chebyshev.lisp
+++ b/static-dispatch/chebyshev.lisp
@@ -1,0 +1,1 @@
+../src/../src/chebyshev.lisp

--- a/static-dispatch/elementwise.lisp
+++ b/static-dispatch/elementwise.lisp
@@ -1,0 +1,1 @@
+../src/../src/elementwise.lisp

--- a/static-dispatch/extended-real.lisp
+++ b/static-dispatch/extended-real.lisp
@@ -1,0 +1,1 @@
+../src/../src/extended-real.lisp

--- a/static-dispatch/interval.lisp
+++ b/static-dispatch/interval.lisp
@@ -1,0 +1,1 @@
+../src/../src/interval.lisp

--- a/static-dispatch/log-exp.lisp
+++ b/static-dispatch/log-exp.lisp
@@ -1,0 +1,1 @@
+../src/../src/log-exp.lisp

--- a/static-dispatch/matrix-shorthand.lisp
+++ b/static-dispatch/matrix-shorthand.lisp
@@ -1,0 +1,1 @@
+../src/../src/matrix-shorthand.lisp

--- a/static-dispatch/matrix.lisp
+++ b/static-dispatch/matrix.lisp
@@ -1,0 +1,1 @@
+../src/../src/matrix.lisp

--- a/static-dispatch/num=.lisp
+++ b/static-dispatch/num=.lisp
@@ -1,0 +1,1 @@
+../src/../src/num=.lisp

--- a/static-dispatch/packages.lisp
+++ b/static-dispatch/packages.lisp
@@ -1,0 +1,319 @@
+;;; -*- Mode: LISP; Base: 10; Syntax: ANSI-Common-Lisp; Package: CL-USER -*-
+
+(cl:defpackage #:num-utils.utilities
+  (:use #:static-dispatch-cl
+        #:alexandria
+        #:anaphora
+        #:let-plus)
+  (:export
+   #:gethash*
+   #:splice-when
+   #:splice-awhen
+   #:curry*
+   #:check-types
+   #:define-with-multiple-bindings
+   #:within?
+   #:fixnum?
+   #:simple-fixnum-vector
+   #:simple-single-float-vector
+   #:as-simple-fixnum-vector
+   #:simple-boolean-vector
+   #:as-bit-vector
+   #:as-double-float
+   #:with-double-floats
+   #:simple-double-float-vector
+   #:make-vector
+   #:generate-sequence
+   #:expanding
+   #:bic
+   #:binary-search
+   #:sequencep				;remove and use alexandria?
+   #:as-alist
+   #:as-plist)
+  (:documentation "A collection of utilities to work with floating point values. Optimised for double-float."))
+
+(defpackage #:num-utils.arithmetic
+  (:use #:static-dispatch-cl
+        #:alexandria-2
+    #:alexandria+
+        #:anaphora
+        #:num-utils.utilities
+        #:let-plus)
+  (:export
+   #:same-sign-p
+   #:square
+   #:cube
+   #:absolute-square
+   #:abs-diff
+   #:log10
+   #:log2
+   #:1c
+   #:divides?
+   #:as-integer
+   #:numseq
+   #:ivec
+   #:sum
+   #:product
+   #:cumulative-sum
+   #:cumulative-product
+   #:l2norm-square
+   #:l2norm
+   #:normalize-probabilities
+   #:floor*
+   #:ceiling*
+   #:round*
+   #:truncate*
+   #:sequence-maximum
+   #:sequence-minimum))
+
+(defpackage #:num-utils.num=
+  (:use #:static-dispatch-cl
+        #:alexandria
+        #:anaphora
+        #:let-plus)
+  (:export
+   #:num-delta
+   #:*num=-tolerance*
+   #:num=
+   #:num=-function
+   #:define-num=-with-accessors
+   #:define-structure-num=))
+
+(defpackage #:num-utils.interval
+  (:use #:static-dispatch-cl
+        #:alexandria
+        #:anaphora
+        #:num-utils.num=
+        #:num-utils.utilities
+        #:let-plus)
+  (:export
+   #:left
+   #:open-left?
+   #:right
+   #:open-right?
+   #:&interval
+   #:interval
+   #:finite-interval
+   #:plusinf-interval
+   #:minusinf-interval
+   #:real-line
+   #:plusminus-interval
+   #:interval-length
+   #:interval-midpoint
+   #:in-interval?
+   #:extend-interval
+   #:extendf-interval
+   #:interval-hull
+   #:relative
+   #:spacer
+   #:split-interval
+   #:shrink-interval
+   #:grid-in
+   #:subintervals-in
+   #:shift-interval))
+
+(defpackage #:num-utils.chebyshev
+  (:use #:static-dispatch-cl
+        #:alexandria
+        #:anaphora
+        #:num-utils.interval
+        #:num-utils.utilities
+        #:let-plus)
+  (:export ; These should probably be renamed in verb-object form
+   #:chebyshev-root
+   #:chebyshev-roots
+   #:chebyshev-regression
+   #:evaluate-chebyshev
+   #:chebyshev-approximate))
+
+(defpackage #:num-utils.polynomial
+  (:use #:static-dispatch-cl
+        #:alexandria
+        #:num-utils.utilities)
+  (:nicknames #:poly)
+  (:export #:evaluate-polynomial #:evaluate-rational)
+  (:documentation "Efficient evaluation of polynomial functions using Horner's method"))
+
+(cl:defpackage #:num-utils.elementwise
+  (:use #:static-dispatch-cl
+        #:alexandria
+        #:num-utils.arithmetic
+        #:num-utils.utilities
+        #:let-plus)
+  (:nicknames #:elmt)			;num-util elementwise mathmatics
+  (:export
+   #:elementwise-float-contagion
+   #:e+
+   #:e-
+   #:e*
+   #:e/
+   #:e2+
+   #:e2-
+   #:e2*
+   #:e2/
+   #:e1-
+   #:e1/
+   #:e2log
+   #:e2exp
+   #:e2mod
+   #:e1log
+   #:e1exp
+   #:eexpt
+   #:eexp
+   #:elog
+   #:emod
+   #:esqrt
+   #:efloor
+   #:eceiling
+   #:econjugate
+   #:esquare
+   #:ereduce
+   #:emin
+   #:emax
+   #:esin
+   #:ecos
+   #:e2<
+   #:e2<=
+   #:e2>
+   #:e2>=
+   #:e2=))
+
+(defpackage #:num-utils.extended-real
+  (:use #:static-dispatch-cl #:alexandria)
+  (:nicknames #:xreal)
+  (:shadow #:= #:< #:> #:<= #:>=)
+  (:export
+   :infinite?
+   :extended-real
+   :=
+   :<
+   :>
+   :<=
+   :>=
+   :plusinf
+   :minusinf
+   :with-template
+   :lambda-template))
+
+(cl:defpackage #:num-utils.print-matrix
+  (:use #:static-dispatch-cl
+        #:alexandria
+        #:anaphora
+        #:let-plus)
+  (:export
+   #:print-length-truncate
+   #:*print-matrix-precision*
+   #:print-matrix))
+
+(cl:defpackage #:num-utils.matrix
+  (:use #:static-dispatch-cl
+        #:alexandria
+        #:anaphora
+        #:num-utils.elementwise
+        #:num-utils.num=
+        #:num-utils.print-matrix
+        #:num-utils.utilities
+        #:select
+        #:let-plus)
+  (:export
+   #:diagonal-vector
+   #:diagonal-matrix
+   #:wrapped-matrix
+   #:lower-triangular-matrix
+   #:upper-triangular-matrix
+   #:triangular-matrix
+   #:hermitian-matrix
+   #:diagonal-matrix-elements
+   #:wrapped-matrix-elements
+   #:transpose
+   #:map-array))
+
+(cl:defpackage #:num-utils.matrix-shorthand
+  (:nicknames #:nu.mx)
+  (:use #:static-dispatch-cl
+        #:alexandria
+        #:anaphora
+        #:num-utils.matrix
+        #:num-utils.utilities
+        #:let-plus)
+  (:export
+   #:vec
+   #:mx
+   #:diagonal-mx
+   #:lower-triangular-mx
+   #:hermitian-mx
+   #:upper-triangular-mx))
+
+(cl:defpackage #:num-utils.quadrature
+  (:use #:static-dispatch-cl
+        #:alexandria
+    #:alexandria+
+        #:anaphora
+        #:num-utils.arithmetic
+        #:num-utils.interval
+        #:num-utils.utilities
+        #:let-plus)
+  (:export
+   #:romberg-quadrature))
+
+(cl:defpackage #:num-utils.rootfinding
+  (:use #:static-dispatch-cl
+        #:alexandria
+        #:num-utils.interval
+        #:num-utils.utilities
+        #:let-plus)
+  (:export
+   #:*rootfinding-epsilon*
+   #:*rootfinding-delta-relative*
+   #:root-bisection))
+
+(uiop:define-package #:num-utils.log-exp
+    (:use #:static-dispatch-cl #:let-plus)
+
+  (:import-from #:num-utils.arithmetic
+        #:ln
+        #:square)
+  (:import-from #:num-utils.polynomial
+        #:evaluate-polynomial)
+  (:import-from #:num-utils.utilities
+        #:simple-double-float-vector)
+
+  (:export #:log1+
+       #:log1-
+       #:log1+/x
+       #:exp-1
+       #:exp-1/x
+       #:expt-1
+       #:log1-exp
+       #:log1+exp
+       #:log2-exp
+       #:logexp-1
+       #:hypot
+       #:log1pmx))
+
+(cl:defpackage #:num-utils.test-utilities
+  (:use #:static-dispatch-cl)
+
+  (:import-from #:num-utils.num=
+        #:num-delta)
+
+  (:import-from #:num-utils.arithmetic
+        #:square)
+
+  (:export #:test-results
+
+       ;; struct accessors
+       #:worst-case ; row at which the worst error occurred
+       #:min-error  ; smallest relative error found
+       #:max-error  ; largest relative error found
+       #:mean-error ; mean error found
+       #:test-count ; number of test cases
+       #:variance0  ; variance of the errors found
+       #:variance1  ; unbiased variance of the errors found
+       #:rms        ; Root Mean Square, or quadratic mean of the error
+
+       ;; Testing functions
+       #:test-fn
+       #:compare-fns
+       #:compare-vectors))
+

--- a/static-dispatch/pkgdcl.lisp
+++ b/static-dispatch/pkgdcl.lisp
@@ -1,0 +1,1 @@
+../src/../src/pkgdcl.lisp

--- a/static-dispatch/polynomial.lisp
+++ b/static-dispatch/polynomial.lisp
@@ -1,0 +1,1 @@
+../src/../src/polynomial.lisp

--- a/static-dispatch/print-matrix.lisp
+++ b/static-dispatch/print-matrix.lisp
@@ -1,0 +1,1 @@
+../src/../src/print-matrix.lisp

--- a/static-dispatch/quadrature.lisp
+++ b/static-dispatch/quadrature.lisp
@@ -1,0 +1,1 @@
+../src/../src/quadrature.lisp

--- a/static-dispatch/rootfinding.lisp
+++ b/static-dispatch/rootfinding.lisp
@@ -1,0 +1,1 @@
+../src/../src/rootfinding.lisp

--- a/static-dispatch/test-utilities.lisp
+++ b/static-dispatch/test-utilities.lisp
@@ -1,0 +1,1 @@
+../src/../src/test-utilities.lisp

--- a/static-dispatch/utilities.lisp
+++ b/static-dispatch/utilities.lisp
@@ -1,0 +1,1 @@
+../src/../src/utilities.lisp


### PR DESCRIPTION
This is still of limited use though.

1. It does not emit compiler notes when static-dispatch fails. This will require changes in static-dispatch itself.
2. It still needs a fair amount of declarations and inlining to actually get much benefits out of this approach. 

In the upcoming commits, I will attempt the second task. For example, the following shows a generic-+ in its disassembly.

```lisp
(disassemble
 (lambda (x y)
   (declare (optimize speed)
            (type (simple-array single-float 1) x y))
   (num-utils:e2+ x y)))
```

To get rid of it requires one to inline the `ref` inside `mapping-array`. But after doing both of these, we get a 2.5x performance boost on SBCL 2.3.4:

```lisp
CL-USER> (let ((x (aops:rand* 'single-float 1000))
               (y (aops:rand* 'single-float 1000)))
          (declare (notinline num-utils:e2+))
          (time (loop repeat 10000 do (num-utils:e2+ x y))))
Evaluation took:
  0.252 seconds of real time
  0.250618 seconds of total run time (0.250618 user, 0.000000 system)
  99.60% CPU
  553,358,300 processor cycles
  40,972,272 bytes consed
NIL
CL-USER> (let ((x (aops:rand* 'single-float 1000))
               (y (aops:rand* 'single-float 1000)))
           (declare (optimize speed)
                    (type (simple-array single-float 1) x y))
           (time (loop repeat 10000 do (num-utils:e2+ x y))))
Evaluation took:
  0.104 seconds of real time
  0.103522 seconds of total run time (0.103522 user, 0.000000 system)
  100.00% CPU
  228,570,630 processor cycles
  40,938,752 bytes consed
NIL
```

This can be optimized further if we allow for an optional `out` argument to the `e2+` function.